### PR TITLE
Remove duplicate api/index.ts function pattern from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,8 +3,7 @@
   "outputDirectory": "dist/spa",
   "regions": ["gru1"],
   "functions": {
-    "api/**": { "maxDuration": 60, "includeFiles": "dist/server/**" },
-    "api/index.ts": { "maxDuration": 60, "includeFiles": "dist/server/**" }
+    "api/**": { "maxDuration": 60, "includeFiles": "dist/server/**" }
   },
   "routes": [
     { "src": "/api/(.*)", "dest": "/api" },


### PR DESCRIPTION
## Purpose

Fix Vercel build error caused by duplicate function pattern configuration. The user encountered an error where Vercel CLI couldn't match the specific `api/index.ts` pattern, indicating a configuration issue with serverless function definitions.

## Code changes

- Removed duplicate `api/index.ts` function pattern from `vercel.json`
- Kept the more general `api/**` pattern which already covers all API routes including `api/index.ts`
- Maintained the same configuration settings (maxDuration: 60, includeFiles: "dist/server/**") for the remaining pattern

This change eliminates the redundant pattern while preserving the intended serverless function behavior.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 70`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1ed00db18bf2438e9fae1c8dd57658c6/quantum-lab)

👀 [Preview Link](https://1ed00db18bf2438e9fae1c8dd57658c6-quantum-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1ed00db18bf2438e9fae1c8dd57658c6</projectId>-->
<!--<branchName>quantum-lab</branchName>-->