### PR TITLE
Fix server bundle path resolution for Vercel deployment

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -5,10 +5,26 @@ import { fileURLToPath, pathToFileURL } from "url";
 async function loadCreateServer(): Promise<() => any> {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const candidates = [
+    // Direct server sources (when TypeScript is compiled alongside)
     path.join(__dirname, "../server/index.js"),
     path.join(__dirname, "../server/index.mjs"),
     path.join(__dirname, "../../server/index.js"),
+    path.join(__dirname, "../../server/index.mjs"),
     path.join(process.cwd(), "server/index.js"),
+    path.join(process.cwd(), "server/index.mjs"),
+    // Vite server build outputs
+    path.join(__dirname, "../dist/server/index.js"),
+    path.join(__dirname, "../dist/server/index.mjs"),
+    path.join(__dirname, "../dist/server/server.js"),
+    path.join(__dirname, "../dist/server/server.mjs"),
+    path.join(__dirname, "../../dist/server/index.js"),
+    path.join(__dirname, "../../dist/server/index.mjs"),
+    path.join(__dirname, "../../dist/server/server.js"),
+    path.join(__dirname, "../../dist/server/server.mjs"),
+    path.join(process.cwd(), "dist/server/index.js"),
+    path.join(process.cwd(), "dist/server/index.mjs"),
+    path.join(process.cwd(), "dist/server/server.js"),
+    path.join(process.cwd(), "dist/server/server.mjs"),
   ];
   for (const p of candidates) {
     try {
@@ -16,7 +32,7 @@ async function loadCreateServer(): Promise<() => any> {
       if (mod && typeof mod.createServer === "function") return mod.createServer as any;
     } catch {}
   }
-  throw new Error("server/index.js not found in function bundle. Ensure the 'server' directory is included.");
+  throw new Error("Server build not found. Ensure dist/server (Vite server build) is included in the function bundle.");
 }
 
 let _handler: any | null = null;

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "functions": {
     "api/**": {
       "maxDuration": 60,
-      "includeFiles": "server/**"
+      "includeFiles": "dist/server/**"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Purpose
The user was experiencing a deployment error on Vercel where the server bundle could not be found ("server/index.js not found in function bundle"). They were trying to connect to a Supabase API but the deployment was failing due to incorrect server file path resolution in the Vercel function bundle.

## Code changes
- **Expanded server file path candidates**: Added multiple fallback paths to locate the server bundle, including support for both `.js` and `.mjs` extensions
- **Added Vite build output paths**: Included paths for `dist/server/` directory to support Vite server builds (`dist/server/index.js`, `dist/server/server.js`, etc.)
- **Updated Vercel configuration**: Changed `includeFiles` from `server/**` to `dist/server/**` to include the correct build output directory
- **Improved error message**: Updated the error message to be more specific about expecting `dist/server` (Vite server build) in the function bundle

These changes ensure the Vercel deployment can properly locate the server bundle regardless of the build tool or output structure used.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 74`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3ab578daa6bb44d1a6f882a128e1c583/pixel-garden)

👀 [Preview Link](https://3ab578daa6bb44d1a6f882a128e1c583-pixel-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3ab578daa6bb44d1a6f882a128e1c583</projectId>-->
<!--<branchName>pixel-garden</branchName>-->