### PR TITLE
Add bulk profile permissions save functionality

### DIFF
--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -220,6 +220,13 @@ export async function setProfilePermission(perfil: PerfilUsuario, permission: st
   }
 }
 
+export async function saveProfilePermissions(perfil: PerfilUsuario, permissions: string[]): Promise<void> {
+  await api("/api/admin/profile-permissions", {
+    method: "POST",
+    body: JSON.stringify({ profile_name: perfil, permissions }),
+  });
+}
+
 export async function fetchUserPermissions(userId: string): Promise<string[]> {
   return api<string[]>(`/api/admin/user-permissions/${encodeURIComponent(userId)}`);
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import { handleDemo } from "./routes/demo";
-import { createUserAndProfile, listProfiles, listRecentLogins, listRecentActivities, listPermissions, getProfilePermissions, addProfilePermission, removeProfilePermission, importEmployees, getUserPermissions, addUserPermission, removeUserPermission, getUserOverrides, saveUserOverrides, updateUserProfile } from "./routes/admin";
+import { createUserAndProfile, listProfiles, listRecentLogins, listRecentActivities, listPermissions, getProfilePermissions, addProfilePermission, removeProfilePermission, importEmployees, getUserPermissions, addUserPermission, removeUserPermission, getUserOverrides, saveUserOverrides, updateUserProfile, replaceProfilePermissions } from "./routes/admin";
 import { listProcesses } from "./routes/processes";
 
 export function createServer() {

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,7 +31,7 @@ export function createServer() {
   // Permissions management
   app.get("/api/admin/permissions", listPermissions as any);
   app.get("/api/admin/profile-permissions", getProfilePermissions as any);
-  app.post("/api/admin/profile-permissions", addProfilePermission as any);
+  app.post("/api/admin/profile-permissions", replaceProfilePermissions as any);
   app.delete("/api/admin/profile-permissions", removeProfilePermission as any);
   // Per-user permissions
   app.get("/api/admin/user-permissions/:userId", getUserPermissions as any);

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -809,8 +809,10 @@ async function selectUserOverridesFlexible(db: any, userId: string): Promise<Use
   const trySelects = [
     async () => db.from('user_permission_overrides').select('permission_name, action').eq('user_id', userId),
     async () => db.from('user_permission_overrides').select('permission, action').eq('user_id', userId),
+    async () => db.from('user_permission_overrides').select('permission_id, action, permissions ( name )').eq('user_id', userId),
     async () => db.from('user_overrides').select('permission_name, action').eq('user_id', userId),
     async () => db.from('user_overrides').select('permission, action').eq('user_id', userId),
+    async () => db.from('user_overrides').select('permission_id, action, permissions ( name )').eq('user_id', userId),
   ];
   for (const fn of trySelects) {
     try {
@@ -818,10 +820,8 @@ async function selectUserOverridesFlexible(db: any, userId: string): Promise<Use
       if (!error && Array.isArray(data) && data.length > 0) {
         return (data as any[]).map((r: any) => {
           const action: 'grant' | 'revoke' = ((r.action || '').toLowerCase() === 'revoke' ? 'revoke' : 'grant');
-          return {
-            permission_name: r.permission_name || r.permission,
-            action,
-          } as UserOverride;
+          const permission_name = r.permission_name || r.permission || r?.permissions?.name;
+          return { permission_name, action } as UserOverride;
         }).filter((r) => r.permission_name);
       }
     } catch {}

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -815,7 +815,7 @@ async function selectUserOverridesFlexible(db: any, userId: string): Promise<Use
   for (const fn of trySelects) {
     try {
       const { data, error } = await fn();
-      if (!error && Array.isArray(data)) {
+      if (!error && Array.isArray(data) && data.length > 0) {
         return (data as any[]).map((r: any) => {
           const action: 'grant' | 'revoke' = ((r.action || '').toLowerCase() === 'revoke' ? 'revoke' : 'grant');
           return {


### PR DESCRIPTION
## Purpose

The user requested implementation of a bulk profile permissions management system for their Supabase-connected application. They needed to replace the existing individual permission toggle functionality with a batch save approach that allows administrators to modify multiple permissions for a profile and save them all at once through a dedicated API endpoint.

## Code changes

- **Frontend (client/lib/api.ts)**: Added `saveProfilePermissions()` function to call the new bulk save API endpoint
- **Frontend (client/pages/administrador/Permissoes.tsx)**: 
  - Replaced individual permission toggles with local state management
  - Added "Save" button for each profile to commit permission changes
  - Implemented local permission state tracking before saving
- **Backend (server/index.ts)**: Updated route handler to use new `replaceProfilePermissions` function
- **Backend (server/routes/admin.ts)**: Added `replaceProfilePermissions()` function that:
  - Validates admin authentication
  - Converts permission names to IDs
  - Deletes all existing permissions for the profile
  - Inserts the new permission set
  - Handles both `profile_name` and `perfil` column variations for compatibilityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 80`

🔗 [Edit in Builder.io](https://builder.io/app/projects/794a37679c204c37a9157436339e84f5/pixel-garden)

👀 [Preview Link](https://794a37679c204c37a9157436339e84f5-pixel-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>794a37679c204c37a9157436339e84f5</projectId>-->
<!--<branchName>pixel-garden</branchName>-->